### PR TITLE
fixing galaxy install, updating the role definition class to using ve…

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -21,7 +21,6 @@
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
-
 import os.path
 import re
 import shutil
@@ -459,9 +458,9 @@ class GalaxyCLI(CLI):
                             # be found on galaxy.ansible.com
                             continue
                         if dep_role.install_info is None:
-                            if dep_role not in roles_left:
+                            if dep_info not in roles_left:
                                 display.display('- adding dependency: %s' % str(dep_role))
-                                roles_left.append(dep_role)
+                                roles_left.append(dep_info)
                             else:
                                 display.display('- dependency %s already pending installation.' % dep_role.name)
                         else:


### PR DESCRIPTION
…rsioning to look for role based on galaxy naming scheme first, then base role name. Mostly backwards compatible. Will cause new behavior if multiple roles had same dependencies with different versions.The old behavior was to use the first installed role.

##### SUMMARY
- Fixed some issues in galaxy, with object changes dep_role to dep_info
- Updated the role definition to check the new version name before going to default role name
##### ISSUE TYPE
 - Feature Pull Request -> adding ansible role versioning 

##### COMPONENT NAME
ansible galaxy, ansible core
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.6
```
##### ADDITIONAL INFORMATION
@agaffney I have another branch: https://github.com/scottmishra/ansible/tree/samishr/galaxy_multiple_versions2
that has merged in the ansible/ansible:devel branch. But, I dont like the way it looks when I created a pr :D .
A Test Playbook could use the following requirements.yml. These are two very simple roles that have 
a common role dependency (git@github.com:scottmishra/test1.git) at different versions (v1.0, and master)
```
---
- src: git@github.com:scottmishra/test2.git
  scm: git
- src: git@github.com:scottmishra/test3.git
  scm: git
```
